### PR TITLE
fix dataset homepage link

### DIFF
--- a/datacentral.py
+++ b/datacentral.py
@@ -174,6 +174,7 @@ def process_datapackage(pkg_name, repo_dir):
     pkg_info['sources'] = metadata.get('sources')
     pkg_info['version'] = metadata.get('version')
     pkg_info['repository'] = metadata.get('repository')
+    pkg_info['homepage'] = metadata.get('homepage')
     # process README
     readme = ""
     readme_path = os.path.join(pkg_dir, "README.md")

--- a/themes/centraldedados/templates/dataset.html
+++ b/themes/centraldedados/templates/dataset.html
@@ -16,7 +16,9 @@
         <p><strong>Versão</strong> {{ datapkg.version }}</p>
         <p><strong>Licença</strong> {{ datapkg.license }}</p>
         <p><strong>Última atualização</strong> {{ datapkg.last_updated }}</p>
+        {% if datapkg.homepage %}
         <p><a href="{{ datapkg.homepage }}">Ver no GitHub</a></p>
+        {% endif%}
         <hr>
         <div class="downloads">
           <h4>Downloads</h4>


### PR DESCRIPTION
Este pull-request corrige um bug nos links dos datasets.
As páginas dos dataset têm um link para a "homepage" mas como esse campo não estava a ser copiado dos meta-dados não estava disponível quando necessário nos templates.
